### PR TITLE
fix(pubsub2): don't panic on missing pattern event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 *.test
 *.prof
 
+/.idea

--- a/pubsub2/redis_test.go
+++ b/pubsub2/redis_test.go
@@ -81,7 +81,7 @@ func TestRecordsRemoves(t *testing.T) {
 
 func TestRecordFindCopyGetsEmptyByDefault(t *testing.T) {
 	recs := (&recordList{}).FindCopy("foo")
-	assert.Len(t, recs.list, 0)
+	assert.Nil(t, recs)
 }
 
 func TestRecordsGetCopies(t *testing.T) {


### PR DESCRIPTION
There was a race when removing a patterned event. If we unsubscribed locally but there was an event still being sent down the wire, we'd get that and match to nothing. In this case `FindCopy`, when attempting to get a handler for the pattern, would return a "default" structure, but the problem was that this default structure contains a default, empty event, which is _not_ a pattern. When trying to match against the empty event in `matchPatternAgainst`, an assertion causes a panic.