### PR TITLE
panic on index out of range

### DIFF
--- a/worker/default_lifecycle.go
+++ b/worker/default_lifecycle.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -202,6 +203,10 @@ func (l *DefaultLifecycle) removeTask(task *Task) (err error) {
 	// list (left side) might change in the meantime.
 	_, err = cnx.Do("LSET", l.workingTasks.Dest(), i-count, deleteToken)
 	if err != nil {
+		if strings.EqualFold(err.Error(), "ERR index out of range") {
+			// TODO: should we pass this up the stack and let the caller deal with it?
+			panic(err)
+		}
 		return
 	}
 


### PR DESCRIPTION
- I'm actually not totally sold on doing it here
- If we passed it back out, and had stream-stats handle the error and panic, we could at least log, whereas here it'll just panic
- That being said, the panic ends up in the logs is my understanding, right @connor4312 ? So we'll still get the log line that we panic'd