### PR TITLE
fix(pubsub2): deadlockable resubscribe loop

### DIFF
--- a/heartbeat/simple_heart_test.go
+++ b/heartbeat/simple_heart_test.go
@@ -37,11 +37,11 @@ func (suite *SimpleHeartbeatSuite) TestStrategyIsCalledAtInitializationAndInterv
 	strategy := &TestStrategy{}
 	strategy.On("Touch", "foo", "bar", suite.Pool).Return(nil)
 
-	h := heartbeat.NewSimpleHeart("bar", "foo", 5*time.Millisecond, suite.Pool, strategy)
+	h := heartbeat.NewSimpleHeart("bar", "foo", 50*time.Millisecond, suite.Pool, strategy)
 	strategy.AssertNumberOfCalls(suite.T(), "Touch", 1)
 	defer h.Close()
 
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(60 * time.Millisecond)
 
 	strategy.AssertNumberOfCalls(suite.T(), "Touch", 2)
 }


### PR DESCRIPTION
Saw this happen on a server today, the resubscription was running asynchronously while holding the mutex which could, in rare cases, deadlock. Simplified the resubscribe loop and made it run synchronously. Removed the `toWrite` channel drain since that was kind of useless.