### PR TITLE
Feat/redutil perf again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ _testmain.go
 *.prof
 
 /.idea
+/fuzz_record_list-fuzz.zip
+/pubsub2/fuzz_record_list_output
+/*.txt
+/*.zip

--- a/pubsub2/fuzz_record_list/fuzz.go
+++ b/pubsub2/fuzz_record_list/fuzz.go
@@ -1,0 +1,53 @@
+package fuzz
+
+import (
+	"fmt"
+
+	"github.com/mixer/redutil/pubsub2"
+)
+
+var (
+	listeners = []pubsub.Listener{}
+	event     = pubsub.NewEvent()
+)
+
+func init() {
+	for i := 0; i <= 0xFF; i++ {
+		listeners = append(listeners, pubsub.ListenerFunc(func(_ pubsub.Event, _ []byte) {}))
+	}
+}
+
+// Fuzz is the main function for go-fuzz: https://github.com/dvyukov/go-fuzz.
+// It adds and remove users according to the sequence of bytes and ensures
+// state is consistent at the end.
+func Fuzz(data []byte) int {
+	list := pubsub.NewRecordList()
+	isAdded := map[pubsub.Listener]bool{}
+	for i := 0; i < len(data); i++ {
+		listener := listeners[data[i]]
+		if isAdded[listener] {
+			list.Remove(event, listener)
+			isAdded[listener] = false
+		} else {
+			list.Add(event, listener)
+			isAdded[listener] = true
+		}
+	}
+
+	result := list.ListenersFor(event)
+	for i, l := range listeners {
+		exists := false
+		for _, l2 := range result {
+			if l2 == l {
+				exists = true
+				break
+			}
+		}
+
+		if exists != isAdded[l] {
+			panic(fmt.Sprintf("expected listener %d exists=%+v, but it was not", i, isAdded[l]))
+		}
+	}
+
+	return 0
+}

--- a/pubsub2/redis.go
+++ b/pubsub2/redis.go
@@ -113,7 +113,9 @@ func (r *RecordList) Add(ev EventBuilder, fn Listener) int {
 	if rec.inactiveItems == 0 {
 		rec.inactiveItems = len(oldList)
 		newList := make([]unsafe.Pointer, len(oldList)*2+1)
-		copy(newList, oldList)
+		// copy so that the new list items are at the end of the list,
+		// this lets the slot search later run and find free space faster.
+		copy(newList[len(oldList)+1:], oldList)
 		newList[len(oldList)] = unsafe.Pointer(&fn)
 		rec.setList(newList)
 		return newCount

--- a/pubsub2/redis_test.go
+++ b/pubsub2/redis_test.go
@@ -72,13 +72,13 @@ func TestRecordsAddListeners(t *testing.T) {
 
 	list2 := list.getList()
 	assert.Len(t, list2, 1)
-	assertListenersEqual(t, list2[0], ev, "foo", []Listener{l1, l2})
+	assertListenersEqual(t, list2[0], ev, "foo", []Listener{l2, l1})
 }
 
 func TestRecordsRemoves(t *testing.T) {
 	recs, l1, l2 := newTestRecordList()
 	ev := NewEvent("foo")
-	assertListenersEqual(t, recs.getList()[0], ev, "foo", []Listener{l1, l2})
+	assertListenersEqual(t, recs.getList()[0], ev, "foo", []Listener{l2, l1})
 	recs.Remove(NewEvent("foo"), l2)
 	assertListenersEqual(t, recs.getList()[0], ev, "foo", []Listener{l1})
 	recs.Remove(NewEvent("foo"), l1)
@@ -98,16 +98,16 @@ func TestRecordsGetCopies(t *testing.T) {
 	l3 := newMockListener()
 
 	originalList := out.getList()
-	assert.Equal(t, originalList, []Listener{l1, l2})
+	assert.Equal(t, originalList, []Listener{l2, l1})
 	recs.Add(ev, l3)
-	assert.Equal(t, originalList, []Listener{l1, l2})
+	assert.Equal(t, originalList, []Listener{l2, l1})
 
 	updatedList := out.getList()
-	assert.Equal(t, updatedList, []Listener{l1, l2, l3})
+	assert.Equal(t, updatedList, []Listener{l3, l2, l1})
 	recs.Remove(ev, l1)
 	recs.Remove(ev, l2)
-	assert.Equal(t, updatedList, []Listener{l1, l2, l3})
-	assert.Equal(t, originalList, []Listener{l1, l2})
+	assert.Equal(t, updatedList, []Listener{l3, l2, l1})
+	assert.Equal(t, originalList, []Listener{l2, l1})
 	assert.Equal(t, out.getList(), []Listener{l3})
 }
 

--- a/pubsub2/redis_test.go
+++ b/pubsub2/redis_test.go
@@ -38,8 +38,8 @@ func newMockListener() *mockListener {
 	return &mockListener{called: make(chan struct{}, 1)}
 }
 
-func newTestRecordList() (recs *recordList, l1 Listener, l2 Listener) {
-	recs = newRecordList()
+func newTestRecordList() (recs *RecordList, l1 Listener, l2 Listener) {
+	recs = NewRecordList()
 	l1 = newMockListener()
 	l2 = newMockListener()
 
@@ -56,7 +56,7 @@ func assertListenersEqual(t *testing.T, r *record, event EventBuilder, name stri
 }
 
 func TestRecordsAddListeners(t *testing.T) {
-	list := newRecordList()
+	list := NewRecordList()
 	ev := NewEvent("foo")
 	l1 := newMockListener()
 	l2 := newMockListener()
@@ -86,7 +86,7 @@ func TestRecordsRemoves(t *testing.T) {
 }
 
 func TestRecordFindCopyGetsEmptyByDefault(t *testing.T) {
-	i, recs := newRecordList().Find("foo")
+	i, recs := NewRecordList().Find("foo")
 	assert.Equal(t, -1, i)
 	assert.Nil(t, recs)
 }
@@ -121,10 +121,10 @@ func TestRaceGuarantees(t *testing.T) {
 	// this test will fail with the race detector enabled if anything that's
 	// not thread-safe happens.
 
-	recs := newRecordList()
+	recs := NewRecordList()
 	ev1 := NewEvent("foo")
 	ev2 := NewEvent("bar")
-	until := time.Now().Add(100 * time.Millisecond)
+	until := time.Now().Add(500 * time.Millisecond)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -295,7 +295,7 @@ func (r *RedisPubsubSuite) TestResubscribesWhenDies() {
 	l.waitForCall()
 }
 
-func createBenchmarkList(count int, removeEvery int) (listeners []*Listener, recordInst *record, recordList *recordList) {
+func createBenchmarkList(count int, removeEvery int) (listeners []*Listener, recordInst *record, recordList *RecordList) {
 	listeners = make([]*Listener, count)
 	for i := 0; i < count; i++ {
 		wrapped := ListenerFunc(func(_ Event, _ []byte) {})
@@ -304,7 +304,7 @@ func createBenchmarkList(count int, removeEvery int) (listeners []*Listener, rec
 
 	recordInst = &record{list: unsafe.Pointer(&listeners)}
 	recordInner := []*record{recordInst}
-	recordList = newRecordList()
+	recordList = NewRecordList()
 	recordList.list = unsafe.Pointer(&recordInner)
 
 	for i := removeEvery; i < count; i += removeEvery {


### PR DESCRIPTION
This significant improves the performance of subscriptions and unsubscriptions from listeners, at the expense of 5-10% slower event broadcasts.

```
benchmark                       old ns/op     new ns/op     delta
BenchmarkRecordAdd1K-8          4820          439           -90.89%
BenchmarkRecordAdd10K-8         164112        3901          -97.62%
BenchmarkRecordAdd100K-8        5522661       34703         -99.37%
BenchmarkRecordRemove1K-8       4882          78.8          -98.39%
BenchmarkRecordRemove10K-8      165169        78.3          -99.95%
BenchmarkRecordRemove100K-8     5663729       138           -100.00%
```

Previously, we had a list of subscriptions made copy-on-writes upon that list, while reads were atomic. However, this meant that subscriptions and unsubscriptions with many listeners became quite expensive.

In the new strategy, the list is instead a sequence of unsafe.Pointer's to Listener interfaces. We read these atomically when running broadcasts. The list can be 'sparse' in that there are nil pointers: when unsubscribing from an event, its pointer is nil'd in the list, or rewritten if the number of active listeners is below a density threshold value. When inserting new entries into the list, we'll try to fill an existing 'nil' slot if one exists, otherwise we'll grow the list (double it in size) which frees up lots of other slots. This means that amount of times we need to do a full copy-and-rewrite is in O(log n) for any sequence of subscriptions and unsubscriptions, rather than O(n), leading to performance improvements around 100-10000x with large lists

This includes a fuzzer for the new record list, which found no problems after running about 130 million sequences of insertions/deletions.