### PR TITLE
feat: add ability to connect using TLS

### DIFF
--- a/conn/conn.go
+++ b/conn/conn.go
@@ -77,7 +77,7 @@ func connect(param ConnectionParam) func() (redis.Conn, error) {
 			}...)
 		}
 
-		cnx, err = redis.Dial("tcp", param.Address)
+		cnx, err = redis.Dial("tcp", param.Address, options...)
 		return
 	}
 }


### PR DESCRIPTION
This change adds the ability to connect to Redis instances using TLS. I've also replaced the deprecated `DialTimeout` with `Dial` using options.