### PR TITLE
Fix  based on best practices from Effective Go

### DIFF
--- a/pubsub/client.go
+++ b/pubsub/client.go
@@ -115,7 +115,7 @@ func (c *Client) Listener(kind ListenerType, event string) *Listener {
 	return listener
 }
 
-// Gets the current client state.
+// GetState gets the current client state.
 func (c *Client) GetState() uint8 {
 	c.stateLock.Lock()
 	defer c.stateLock.Unlock()
@@ -319,7 +319,7 @@ func (c *Client) Subscribe(listener *Listener) {
 	c.tasks <- task{Listener: listener, Action: subscribeAction}
 }
 
-// Removes the listener from the list of subscribers. If it's the last one
+// Unsubscribe removes the listener from the list of subscribers. If it's the last one
 // listening to that Redis event, we unsubscribe entirely.
 func (c *Client) Unsubscribe(listener *Listener) {
 	listener.Active = false

--- a/pubsub/events.go
+++ b/pubsub/events.go
@@ -54,12 +54,12 @@ func (e *eventEmitter) addHandlerToMap(ev EventType, h EventHandler, m map[Event
 	}
 }
 
-// Adds a handler that's executed once when an event is emitted.
+// Once adds a handler that's executed once when an event is emitted.
 func (e *eventEmitter) Once(ev EventType, h EventHandler) {
 	e.addHandlerToMap(ev, h, e.once)
 }
 
-// Adds a handler that's executed when an event happens.
+// On adds a handler that's executed when an event happens.
 func (e *eventEmitter) On(ev EventType, h EventHandler) {
 	e.addHandlerToMap(ev, h, e.listeners)
 }

--- a/queue/base_queue.go
+++ b/queue/base_queue.go
@@ -79,7 +79,7 @@ func (q *BaseQueue) SetProcessor(processor Processor) {
 	q.processor = processor
 }
 
-// Takes all elements from the source queue and adds them to this one. This
+// Concat takes all elements from the source queue and adds them to this one. This
 // can be a long-running operation. If a persistent error is returned while
 // moving things, then it will be returned and the concat will stop, though
 // the concat operation can be safely resumed at any time.

--- a/queue/fifo_processor.go
+++ b/queue/fifo_processor.go
@@ -53,7 +53,7 @@ func (f *fifoProcessor) PullTo(cnx redis.Conn, src, dest string,
 	return bytes, nil
 }
 
-// Removes the first element from the source list and adds it to the end
+// Concat removes the first element from the source list and adds it to the end
 // of the destination list. ErrNil is returns when the source is empty.
 func (f *fifoProcessor) Concat(cnx redis.Conn, src, dest string) (err error) {
 	return rlConcat(cnx, src, dest)

--- a/queue/lifo_processor.go
+++ b/queue/lifo_processor.go
@@ -57,7 +57,7 @@ func (l *lifoProcessor) PullTo(cnx redis.Conn, src, dest string,
 	return bytes, nil
 }
 
-// Removes the first element from the source list and adds it to the end
+// Concat removes the first element from the source list and adds it to the end
 // of the destination list. ErrNil is returns when the source is empty.
 func (l *lifoProcessor) Concat(cnx redis.Conn, src, dest string) (err error) {
 	bytes, err := l.PullTo(cnx, src, dest, 0*time.Second)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?